### PR TITLE
Read playerId from message, not from map

### DIFF
--- a/snakebot-csharp/src/Cygni.Snake.Client/Map.cs
+++ b/snakebot-csharp/src/Cygni.Snake.Client/Map.cs
@@ -102,17 +102,16 @@ namespace Cygni.Snake.Client
             return GetResultOfDirection(playerId, dir).Equals(DirectionalResult.Death) == false;
         }
 
-        public static Map FromJson(string json)
+        public static Map FromJson(string json, string playerId)
         {
-            return FromJson(JObject.Parse(json));
+            return FromJson(JObject.Parse(json), playerId);
         }
 
-        public static Map FromJson(JObject json)
+        public static Map FromJson(JObject json, string playerId)
         {
             int width = (int)json["width"];
             int height = (int)json["height"];
-            int tick = (int)json["worldTick"];
-            string myId = (string) json["receivingPlayerId"];
+            int tick = (int)json["worldTick"];            
 
             var snakes = json["snakeInfos"].Select(token =>
             {
@@ -123,7 +122,7 @@ namespace Cygni.Snake.Client
                 return new SnakePlayer(id, name, points, positions);
             }).ToList();
 
-            var mySnake = snakes.FirstOrDefault(s => s.Id.Equals(myId));
+            var mySnake = snakes.FirstOrDefault(s => s.Id.Equals(playerId));
 
             var foods = json["foodPositions"].Select(i => MapCoordinate.FromIndex((int) i, width));
             var obstacles = json["obstaclePositions"].Select(i => MapCoordinate.FromIndex((int) i, width));

--- a/snakebot-csharp/src/Cygni.Snake.Client/SnakeClient.cs
+++ b/snakebot-csharp/src/Cygni.Snake.Client/SnakeClient.cs
@@ -194,13 +194,13 @@ namespace Cygni.Snake.Client
 
         private void OnGameEnded(JObject json)
         {
-            var map = Map.FromJson((JObject)json["map"]);
+            var map = Map.FromJson((JObject)json["map"], (string) json["receivingPlayerId"]);
             _observer.OnGameEnd(map);
         }
 
         private void OnMapUpdated(SnakeBot snake, JObject json)
         {
-            var map = Map.FromJson((JObject)json["map"]);
+            var map = Map.FromJson((JObject)json["map"], (string)json["receivingPlayerId"]);
             _observer.OnUpdate(map);
             var direction = snake.GetNextMove(map);
             SendRegisterMoveRequest(direction, map.Tick, (string)json["gameId"]);

--- a/snakebot-csharp/test/Cygni.Snake.Client.Tests/MapTests.cs
+++ b/snakebot-csharp/test/Cygni.Snake.Client.Tests/MapTests.cs
@@ -49,7 +49,7 @@ namespace Cygni.Snake.Client.Tests
         {
             var json = TestResources.GetResourceText("map.json", Encoding.UTF8);
 
-            var map = Map.FromJson(json);
+            var map = Map.FromJson(json,"id_python");
 
             Assert.Equal(2, map.Snakes.Count);
         }
@@ -59,7 +59,7 @@ namespace Cygni.Snake.Client.Tests
         {
             var json = TestResources.GetResourceText("map.json", Encoding.UTF8);
 
-            var map = Map.FromJson(json);
+            var map = Map.FromJson(json,"id_python");
 
             Assert.Equal(2, map.Snakes[0].Positions.Count);
             Assert.Equal(1, map.Snakes[0].Positions[0].X);
@@ -79,7 +79,7 @@ namespace Cygni.Snake.Client.Tests
         {
             var json = TestResources.GetResourceText("map.json", Encoding.UTF8);
 
-            var map = Map.FromJson(json);
+            var map = Map.FromJson(json,"id_python");
             
             Assert.Equal("id_python", map.MySnake.Id);
         }


### PR DESCRIPTION
Looks like receivingPlayerId is null in the map object. So read it from the message instead.